### PR TITLE
use sudo to do chef gem install

### DIFF
--- a/mac
+++ b/mac
@@ -236,7 +236,7 @@ cask_install 'textexpander'
 cask_install 'vagrant'
 cask_install 'virtualbox'
 
-chef gem install slack-notifier
+sudo chef gem install slack-notifier
 
 if ! command -v rcup >/dev/null; then
   brew_tap 'thoughtbot/formulae'


### PR DESCRIPTION
I know I removed it the last time.

But it looks like a fresh `brew install chefdk` installs everything as root.

Is this working with you or just a problem with El Capitan?

cc @freistil/ops 
