### PR TITLE
Removed modification of zshrc for rbenv

### DIFF
--- a/mac
+++ b/mac
@@ -183,9 +183,6 @@ brew_install_or_upgrade 'wemux'
 brew_install_or_upgrade 'wget'
 brew_install_or_upgrade 'zsh'
 
-# shellcheck disable=SC2016
-append_to_zshrc 'eval "$(rbenv init - --no-rehash zsh)"' 1
-
 brew_install_or_upgrade 'openssl'
 brew unlink openssl && brew link openssl --force
 


### PR DESCRIPTION
IMHO this script should not modify shell configuration files; that's what we have our dotfiles repositories for.
And at least the zsh configuration already has it built in.

@freistil/ops What do you think?
