### PR TITLE
Remove install of GUI applications

### DIFF
--- a/mac
+++ b/mac
@@ -209,13 +209,6 @@ gem_install_or_update 'hetzner-bootstrap'
 gem_install_or_update 'hetzner-api'
 
 brew_tap 'caskroom/cask'
-cask_install '1password'
-cask_install 'backblaze'
-cask_install 'flux'
-cask_install 'github'
-cask_install 'iterm2'
-cask_install 'rescuetime'
-cask_install 'screenhero'
 cask_install 'vagrant'
 cask_install 'virtualbox'
 


### PR DESCRIPTION
I've encountered some little weirdnesses after applications like 1PW did
a self-update. In order to keep these effects to a minimum, I suggest
reducing the cask installs to CLI tools used by the ops team. This way,
a non-ops user can do standard updates on their machines without
requiring internal tech support.

@freistil/ops Too minimalistic?