### PR TITLE
remove installation of sudolikeaboss

### DIFF
--- a/mac
+++ b/mac
@@ -181,9 +181,6 @@ brew_install_or_upgrade 'wemux'
 brew_install_or_upgrade 'wget'
 brew_install_or_upgrade 'zsh'
 
-brew_tap 'ravenac95/sudolikeaboss'
-brew_install_or_upgrade 'sudolikeaboss'
-
 brew_install_or_upgrade 'openssl'
 brew unlink openssl && brew link openssl --force
 


### PR DESCRIPTION
It's broken after almost every upgrade and iTerm2 provides a nice password manager as well. 

Create a trigger in iTerm2 and it even pop ups the password manager window when using sudo: http://d.pr/i/mr4Z

@freistil/ops are you ok with this?